### PR TITLE
Updated Create CLA Group Logic

### DIFF
--- a/cla-backend-go/v2/cla_groups/helpers.go
+++ b/cla-backend-go/v2/cla_groups/helpers.go
@@ -198,7 +198,7 @@ func (s *service) validateEnrollProjectsInput(ctx context.Context, foundationSFI
 	projectTree := buildProjectNode(foundationProjectSummary)
 	log.WithFields(f).Debugf("projectTree: %+v", projectTree)
 
-	invalidSiblingProjects := []string{}
+	var invalidSiblingProjects []string
 	// Check to see if CLAGroup at ProjectLevel has no siblings
 	if projectLevel {
 		log.WithFields(f).Debugf("checking to see if CLAGroup at ProjectLevel has no siblings...")

--- a/cla-backend-go/v2/project-service/client.go
+++ b/cla-backend-go/v2/project-service/client.go
@@ -520,3 +520,15 @@ func (pmm *Client) IsAnyProjectTheRootParent(sliceProjectSFID []string) bool {
 
 	return retVal
 }
+
+// RemoveLinuxFoundationParentsFromProjectList removes any Linux Foundation root/parent projects from the list
+func (pmm *Client) RemoveLinuxFoundationParentsFromProjectList(projectList []string) []string {
+	var filteredProjectList []string
+	for _, projectSFID := range projectList {
+		// If not one of our Linux Foundation root/parent projects, then add it to the list
+		if isTLF, err := pmm.IsTheLinuxFoundation(projectSFID); !isTLF && err == nil {
+			filteredProjectList = append(filteredProjectList, projectSFID)
+		}
+	}
+	return filteredProjectList
+}


### PR DESCRIPTION
- added logic to strip out the Linux Foundation or Linux Foundation LLC
  when creating a new CLA Group

Signed-off-by: David Deal <ddeal@linuxfoundation.org>
